### PR TITLE
Change require() to gilt.require()

### DIFF
--- a/tasks/swig-spec/lib/html-runner.js
+++ b/tasks/swig-spec/lib/html-runner.js
@@ -62,7 +62,7 @@
         baseUrl: options.baseUrl,
         deps: specFiles,
         callback: function () {
-          require(specNames, options.callback);
+          gilt.require(specNames, options.callback);
         }
       });
 


### PR DESCRIPTION
require is undefined at this point, changing reference to gilt.require()