### PR TITLE
Change CDN hosts from Akamai hosts to Cloudflare hosts (a5..a8)

### DIFF
--- a/tasks/swig-minify/index.js
+++ b/tasks/swig-minify/index.js
@@ -61,8 +61,8 @@ module.exports = function (gulp, swig) {
       // into this:
       //  //assets[n].giltcdn.com/img/web-mosaic/1.0.0/nav/footer/footer-sprite.png
       replaceFn = function (match, leading, imgDir, target, asset) {
-        var min = 1,
-          max = 4,
+        var min = 5,
+          max = 8,
           assetServer = Math.floor(Math.random() * (max - min + 1)) + min,
           result;
 


### PR DESCRIPTION
Noticed from Eric Shepherd's mail on June 10th that we've deprecated Akamai CDN hosts (a1..a4) in favour of the Cloudflare hosts (a5..a8). Making a small PR to update the URL rewrite rules in Swig. I think this is the only place we explicitly reference them...