### PR TITLE
Fix swig init - npm install "Error: stdout maxBuffer exceeded"

### DIFF
--- a/swig-cli/etc/init
+++ b/swig-cli/etc/init
@@ -18,6 +18,10 @@
 var fs = require('fs'),
   path = require('path'),
   exec = require('child_process').exec,
+  execOpts = {
+    maxBuffer: 500*1024       // default is 200*1024
+  },
+  npmInstallError = null,
   templates = {
     gulpfile: fs.readFileSync(path.join(__dirname, '../templates/gulpfile.js')),
     pkg: fs.readFileSync(path.join(__dirname, '../templates/package.json'))
@@ -64,14 +68,18 @@ else {
 console.log('Running npm install...'.yellow);
 
 // run ui install
-var cp = exec('npm install --loglevel=http 2>&1', function (error, stdout, stderr){
+var cp = exec('npm install --loglevel=http 2>&1', execOpts, function (error, stdout, stderr){
   if (error) {
-    console.log(error);
+    npmInstallError = error.toString();
   }
 });
 
-cp.on('exit', function () {
-  console.log('Swig initialization is complete. Feel free to make loud animal noises.'.green);
+cp.on('close', function () {
+  if (npmInstallError !== null) {
+    console.log(('Swig initialization failed on npm install. ' + npmInstallError).red);
+  } else {
+    console.log('Swig initialization is complete. Feel free to make loud animal noises.'.green);
+  }
 });
 
 (function capture (stdout) {

--- a/swig-cli/package.json
+++ b/swig-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swig-cli",
   "description": "",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Fix npm install error via child process "Error: stdout maxBuffer exceeded."

 - Increased Max Buffer size to 500Kb (default 200Kb)
 - Show appropriate success/failure if child process fails on 'close'