### PR TITLE
Preparing swig-install for npmjs.org Private Modules scoping

### DIFF
--- a/src/tasks/swig-install/lib/main-js.js
+++ b/src/tasks/swig-install/lib/main-js.js
@@ -44,10 +44,16 @@ module.exports = function (gulp, swig, paths) {
   });
 
   // load the config dependencies
-  glob.sync(path.join(swig.temp, '/**/node_modules/**/package.json')).forEach(function (file) {
+  glob.sync(path.join(swig.temp, '/**/node_modules/@gilt-tech/**/package.json')).forEach(function (file) {
     pkg = JSON.parse(fs.readFileSync(file, { encoding: 'utf-8' }));
     if (pkg.configDependencies) {
       configDeps = _.extend(configDeps, pkg.configDependencies);
+    }
+    else if (pkg.gilt.configDependencies) {
+      configDeps = _.extend(configDeps, pkg.gilt.configDependencies);
+    }
+    else if (pkg.gilt.configDefaults) {
+      configDeps = _.extend(configDeps, pkg.gilt.configDefaults);
     }
   });
 

--- a/src/tasks/swig-install/lib/merge-modules.js
+++ b/src/tasks/swig-install/lib/merge-modules.js
@@ -21,7 +21,7 @@ module.exports = function (gulp, swig) {
       path = require('path'),
       glob = require('glob'),
       util = require('./merge-util')(gulp, swig),
-      modulesPath = path.join(swig.temp, '/node_modules'),
+      modulesPath = path.join(swig.temp, '/**/node_modules/@gilt-tech'),
       packages = glob.sync(path.join(modulesPath, '/**/package.json')),
 
       // we need to merge whatever the app defined (uiDeps) as well

--- a/src/tasks/swig-install/lib/public-directory.js
+++ b/src/tasks/swig-install/lib/public-directory.js
@@ -57,7 +57,7 @@ module.exports = function (gulp, swig) {
 
     swig.log.info('', 'Compiling module list...');
 
-    var modulesPath = path.join(swig.temp, '/**/node_modules'),
+    var modulesPath = path.join(swig.temp, '/**/node_modules/@gilt-tech'),
       modPaths = glob.sync(modulesPath),
       dirs;
 

--- a/src/tasks/swig-install/package.json
+++ b/src/tasks/swig-install/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swig-install",
   "description": "",
-  "version": "0.0.18",
+  "version": "0.1.0",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",

--- a/src/tasks/swig-publish/index.js
+++ b/src/tasks/swig-publish/index.js
@@ -102,6 +102,7 @@ module.exports = function (gulp, swig) {
   gulp.task('publish-npm', ['publish-check-version'], co(function * () {
 
     var tempPath = path.join(swig.temp, '/publish/', swig.argv.module),
+      tagFlag = '',
       result,
       streamResult;
 
@@ -125,12 +126,19 @@ module.exports = function (gulp, swig) {
       result = yield swig.exec('xattr -c ' + file);
     }));
 
+    // if the version contains a hypen, then assume that we're publishing
+    // a test version. this keeps the module from being tagged as `latest`
+    // in the registry.
+    if (swig.pkg.version.indexOf('-') > 0) {
+      tagFlag = ' --tag=test'; // leading space is important
+    }
+
     try {
 
       // run npm against the temp module location, redirect stderr to stdout
       npmCommand = [
         'cd ' + tempPath,
-        'npm publish . --tag=null --loglevel=info 2>&1'
+        'npm publish .' + tagFlag + ' --loglevel=info 2>&1'
       ].join('; ');
 
       swig.log.info('', 'NPM Command:\n  ' + npmCommand.splt('; ').join(';\n  '));

--- a/src/tasks/swig-publish/package.json
+++ b/src/tasks/swig-publish/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swig-publish",
   "description": "",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
This is an ongoing PR and SHOULD NOT be merged just yet.

Gilt is moving modules to the npmjs.org private, scoped setup and this change will be required to complete that migration.