### PR TITLE
NOJIRA: Warnings in Less reporter causing exit

### DIFF
--- a/src/tasks/swig-lint/lib/reporters/lesshint-reporter.js
+++ b/src/tasks/swig-lint/lib/reporters/lesshint-reporter.js
@@ -96,7 +96,7 @@ module.exports = function (swig) {
       }
 
       swig.log.error('lint-css', output + '. Please do some cleanup before proceeding.');
-      process.exit(0);
+      
     }
     else if (fatal) {
       output = 'You\'ve got ' + errors.toString().magenta + (errors > 1 ? ' errors' : ' error');


### PR DESCRIPTION
- Running swig spec is exited when more than 10 (maxProblems) warnings
are discovered by the LESS reporter. Warnings are intended to be non-fatal