### PR TITLE
Fix the version detection in swig package.json

### DIFF
--- a/bin/swig
+++ b/bin/swig
@@ -27,7 +27,7 @@ pkg=$(cat $dir/../package.json)
 
 function version {
   prop='version'
-  temp=`echo $pkg | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w $prop | cut -d":" -f2 | sed -e 's/^ *//g' -e 's/ *$//g' `
+  temp=`echo $pkg | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep "$prop:" | cut -d":" -f2 | sed -e 's/^ *//g' -e 's/ *$//g' `
   echo ${temp##*|}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
As a result of us upgrading to NPM v3 there is extra metadata information added to a modules package.json upon installation. In this case there was a blob of information like so:

    "_requested": {
      "name": "@gilt-tech/swig",
      "raw": "@gilt-tech/swig@0.7.5",
      "rawSpec": "0.7.5",
      "scope": "@gilt-tech",
      "spec": "0.7.5",
      "type": "version"
    },

The added property `"type": "version"` was throwing off the version detection as at one point we simply grepped for the word "version". We now grep for the trailing colon indicating that it is a property name and not the value.