### PR TITLE
Fix webapp target name

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,8 @@ module.exports = function (gulp) {
   setupPaths();
   findTarget();
 
-  var packagePath = path.join(swig.target.path, 'package.json');
+  var packagePath = path.join(swig.target.path, 'package.json'),
+    targetName = swig.target.name;
 
   if (fs.existsSync(packagePath)) {
     swig.pkg = require(packagePath);
@@ -201,7 +202,7 @@ module.exports = function (gulp) {
   }
 
   console.log('·  ' + 'gulpfile:    '.blue + module.parent.id.replace(process.env.HOME, '~').grey);
-  console.log('·  ' + 'target:      '.blue + (target ? (target || '').grey : 'NO TARGET'.yellow));
+  console.log('·  ' + 'target:      '.blue + (targetName ? targetName.grey : 'NO TARGET'.yellow));
   console.log('·  ' + 'target-path: '.blue + swig.target.path.grey + '\n');
 
   // create swigs's temporary directory;

--- a/index.js
+++ b/index.js
@@ -93,7 +93,6 @@ module.exports = function (gulp) {
   function findTarget () {
 
     var target,
-      moduleName,
       repo = swig.argv.repo || '';
 
     if (swig.argv.m) {
@@ -125,9 +124,15 @@ module.exports = function (gulp) {
       swig.project.type = 'webapp';
     }
 
+    var packagePath = path.join(target, 'package.json');
+
+    if (fs.existsSync(packagePath)) {
+      swig.pkg = require(packagePath);
+    }
+
     swig.target = {
       path: target,
-      name: swig.argv.module || path.basename(target),
+      name: swig.argv.module || (swig.pkg && swig.pkg.name) || path.basename(target),
       repo: swig.argv.repo || path.basename(swig.cwd)
     };
   }
@@ -187,13 +192,8 @@ module.exports = function (gulp) {
   var packagePath = path.join(swig.target.path, 'package.json'),
     targetName = swig.target.name;
 
-  if (fs.existsSync(packagePath)) {
+  if (!swig.pkg && fs.existsSync(packagePath)) {
     swig.pkg = require(packagePath);
-
-    // if package has a name use it for the target.name
-    if (swig.pkg.name) {
-      swig.target.name = swig.pkg.name;
-    }
   }
 
   findSwigRc();

--- a/index.js
+++ b/index.js
@@ -189,6 +189,11 @@ module.exports = function (gulp) {
 
   if (fs.existsSync(packagePath)) {
     swig.pkg = require(packagePath);
+
+    // if package has a name use it for the target.name
+    if (swig.pkg.name) {
+      swig.target.name = swig.pkg.name;
+    }
   }
 
   findSwigRc();

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function (gulp) {
     fs = require('fs'),
     argv = require('yargs').argv,
     target,
+    targetName,
     taskDeps,
     taskName = argv._.length > 0 ? argv._[0] : 'default',
     thisPkg = require('./package.json'),
@@ -130,6 +131,10 @@ module.exports = function (gulp) {
       swig.pkg = require(packagePath);
     }
 
+    if (_.isEmpty(swig.pkg)) {
+      console.log('.  ' + 'warning!    '.yellow + ' package.json not found at: ' + packagePath.grey);
+    }
+
     swig.target = {
       path: target,
       name: swig.argv.module || (swig.pkg && swig.pkg.name) || path.basename(target),
@@ -183,28 +188,17 @@ module.exports = function (gulp) {
     console.log('·');
   }
 
+  console.log('·  ' + 'swig (local)'.red + ' v' + thisPkg.version + '\n·');
+
   swig.util = require('@gilt-tech/swig-util')(swig, gulp);
   swig.tell = tell;
 
+  findSwigRc();
+  checkLocalVersion();
   setupPaths();
   findTarget();
 
-  var packagePath = path.join(swig.target.path, 'package.json'),
-    targetName = swig.target.name;
-
-  if (!swig.pkg && fs.existsSync(packagePath)) {
-    swig.pkg = require(packagePath);
-  }
-
-  findSwigRc();
-
-  console.log('·  ' + 'swig (local)'.red + ' v' + thisPkg.version + '\n·');
-
-  checkLocalVersion();
-
-  if (_.isEmpty(swig.pkg)) {
-    console.log('.  ' + 'warning!    '.yellow + ' package.json not found at: ' + packagePath.grey);
-  }
+  targetName = swig.target.name;
 
   console.log('·  ' + 'gulpfile:    '.blue + module.parent.id.replace(process.env.HOME, '~').grey);
   console.log('·  ' + 'target:      '.blue + (targetName ? targetName.grey : 'NO TARGET'.yellow));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
fix swig.target.name which was being used by other swig task to construct the assets paths (e.g. public/js/{swig-target-name}), previously using the directory name. This was identified when somebody cloned the repo to a folder which had a name differing from the project name in the package.json.