### PR TITLE
fix wonky args: sometimes $@ is empty, thats bad

### DIFF
--- a/bin/swig
+++ b/bin/swig
@@ -12,6 +12,8 @@
 #    It's delicious.
 #    Brought to you by the fine folks at Gilt (http://github.com/gilt)
 
+args=$@
+
 bold=$(tput bold)
 underline=$(tput sgr 0 1)
 reset=$(tput sgr0)
@@ -89,4 +91,4 @@ if [ ! -e "`which gulp`" ]; then
 fi
 
 # pass control to gulp
-node --harmony "$dir/../lib/update.js" && node --harmony --harmony-proxies `which gulp` "$@"
+node --harmony "$dir/../lib/update.js" && gulp $args

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "0.7.10",
+  "version": "0.8.0",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
was stripping the $@ arguments variable. that in turn, was making
swig think that every run of swig was the default task; because there
were effectively no args passed to it.

so we're storing the args right off the bat, and using that variable.

also removed the harmony flags from the gulp call at the end, because
we're using harmonize in swig's index.