### PR TITLE
NOJIRA: Parameters getting lost in Linux

### DIFF
--- a/bin/swig
+++ b/bin/swig
@@ -14,6 +14,11 @@
 
 args=$@
 
+# Sourcing nvm is nuking our parameters on Red Hat linux (Jenkins) so I am going to store the params here.
+command=$0
+firstParam=$1
+secondParam=$2
+
 bold=$(tput bold)
 underline=$(tput sgr 0 1)
 reset=$(tput sgr0)
@@ -22,8 +27,8 @@ red=$(tput setaf 1)
 gray=$(tput setaf 8)
 white=$(tput setaf 7)
 
-dir=`dirname $0`
-bin=`perl -e "print readlink '$0'"`
+dir=`dirname $command`
+bin=`perl -e "print readlink '$command'"`
 dir=`dirname $dir/$bin`
 pkg=$(cat $dir/../package.json)
 
@@ -60,27 +65,27 @@ if [ "$NODE_ENV" != "production" ]; then
   nvm use 5 >/dev/null
 fi
 
-if [ "$1" == "init" ]; then
+if [ "$firstParam" == "init" ]; then
   node --harmony "$dir/../lib/init.js"
   exit
 fi
 
-if [ "$1" == "update" ]; then
+if [ "$firstParam" == "update" ]; then
   node --harmony "$dir/../lib/update.js"
   exit
 fi
 
-if [ "$1" == "pre-publish" ]; then
+if [ "$firstParam" == "pre-publish" ]; then
   node --harmony "$dir/../lib/pre-publish" "$@"
   # --vendor
   # --less
   exit
 fi
 
-if [ "$1" == "help" ]; then
+if [ "$firstParam" == "help" ]; then
   # reset the args passed to wrap the task name we want help with
   # prevents gulp from trying to run two tasks
-  set -- "$1" "--task=$2"
+  set -- "$firstParam" "--task=$secondParam"
 fi
 
 if [ ! -e "`which gulp`" ]; then


### PR DESCRIPTION
- On the Jenkins servers, the parameters to the swig
command were getting lost after a source of nvm.
Gonna store and use them later.