### PR TITLE
🔧  New scripts build approach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,8 @@ before_install:
 script:
   - npm install
   - gulp
+
+# Only build for master & pull-requests
+branches:
+  only:
+    - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+### 1.0.0
+- Breaking Changes:
+  - The reworked `swig assets-deploy` will now produce JS artifacts inside the
+    `public/js/<app-name>/app` folder. The bundler will fetch from that folder
+    and will continue to create merged/minified assets in `public/js/<app-name>`
+    Applications that were defining their dependencies by prefixing their id
+    with `src.` must now change it to `app.` or start using ES6 modules instead.
+
+- Improvements:
+  - Introduced new `swig transpile-scripts` task, used to transform ES6 and
+    React JSX code to ES5 code.
+  - Added new watcher to the run task to automatically transpile scripts:
+    `swig run --watch-scripts`. You can also call it standalone with
+    `swig watch-scripts`.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node": ">= 5.x"
   },
   "dependencies": {
-    "@gilt-tech/swig-assets": "^0.1.0",
+    "@gilt-tech/swig-assets": "^1.0.0",
     "@gilt-tech/swig-bundle": "^1.0.0",
     "@gilt-tech/swig-default": "^0.2.0",
     "@gilt-tech/swig-deps": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "0.8.11",
+  "version": "0.9.0",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",
@@ -31,6 +31,11 @@
       "name": "Rory Haddon",
       "email": "rhaddon@gilt.com",
       "url": "https://github.com/roryh/"
+    },
+    {
+      "name": "Federico Giovagnoli",
+      "email": "fgiovagnoli@gilt.com",
+      "url": "https://github.com/Meesayen/"
     }
   ],
   "licenses": [
@@ -44,7 +49,7 @@
   },
   "dependencies": {
     "@gilt-tech/swig-assets": "^0.1.0",
-    "@gilt-tech/swig-bundle": "^0.1.0",
+    "@gilt-tech/swig-bundle": "^1.0.0",
     "@gilt-tech/swig-default": "^0.2.0",
     "@gilt-tech/swig-deps": "^0.1.0",
     "@gilt-tech/swig-install": "^0.1.0",
@@ -55,6 +60,7 @@
     "@gilt-tech/swig-release-email": "^0.1.0",
     "@gilt-tech/swig-spec": "^0.1.0",
     "@gilt-tech/swig-stub": "^0.1.0",
+    "@gilt-tech/swig-transpile-scripts": "^1.0.0",
     "@gilt-tech/swig-util": "^0.1.0",
     "co": "3.x",
     "colors": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Bumped dependencies versions:
 - `swig-assets` 1.0.0
 - `swig-bundle` 1.0.0

Added new dependency:
 - `swig-transpile-scripts` 1.0.0

Bumped version to 1.0.0. 

The swig scripts build/bundle task changed significantly, check relevant PR on the [gilt-swig-assets](https://github.com/gilt/gilt-swig-assets/pull/36) repository for an overview of the changes.