### PR TITLE
Overridable tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ module.exports = function (gulp) {
   // allows a task to tell swig about itself
   function tell (taskName, taskInfo) {
     if (swig.tasks[taskName]) {
-      throw 'Swig already has a task entry for: ' + taskName;
+      console.log(`Task '${taskName}' has been overridden by a local installation`.yellow);
     }
 
     taskInfo = _.extend({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
It is now possible to override a swig task by installing a different version at project level.

i.e. 

Current `swig` v1.0 depends and imports `swig-lint` v0.3, if a particular project wants to start using a newer version of `swig-lint`, at the moment, it has to wait for `swig` to be upgraded to support newer versions of its dependencies.

With this change, projects can define their own set of dependencies to plug into the `swig` system, for example importing `swig-lint` v1.0 and start using that without waiting for a major/minor change of the `swig` package itself.