### PR TITLE
🐆  Retrocompatible fix for yarn based installations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### 1.2.0
+- Improvement:
+  - Removed call to `harmonize` module for Node 6 and above.
+    The use of this module was creating an issue with `yarn` based installations.
+  - We can now safely use `yarn`! 🍾
+
+
+### 1.1.0
+- Improvement:
+  - Made swig tasks overridable via locally installed dependencies
+
+
 ### 1.0.0
 - Breaking Changes:
   - The reworked `swig assets-deploy` will now produce JS artifacts inside the

--- a/bin/swig
+++ b/bin/swig
@@ -53,16 +53,21 @@ if [ "$NODE_ENV" != "production" ]; then
   export NVM_DIR="$HOME/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-  # run node 5 allow errors to pass through to the user.
+  # run node 5+ allow errors to pass through to the user.
 
-  if ls $NVM_DIR/versions/node/v5.* 1> /dev/null 2>&1; then
-    echo "Node v5 already installed" 1> /dev/null 2>&1
+  if ls $NVM_DIR/versions/node/v6.* 1> /dev/null 2>&1; then
+    echo "Node v6 is installed. Using it." 1> /dev/null 2>&1
+    nvm use 6 >/dev/null
   else
-    echo ".  ${gray}You don't have node v5 installed, doing that now:${reset}"
-    nvm install 5
-  fi
+    if ls $NVM_DIR/versions/node/v5.* 1> /dev/null 2>&1; then
+      echo "Node v5 is installed. Using it." 1> /dev/null 2>&1
+    else
+      echo ".  ${gray}You don't have node v5 installed, isntalling now:${reset}"
+      nvm install 5
+    fi
 
-  nvm use 5 >/dev/null
+    nvm use 5 >/dev/null
+  fi
 fi
 
 if [ "$firstParam" == "init" ]; then

--- a/index.js
+++ b/index.js
@@ -14,13 +14,20 @@
 */
 
 module.exports = function (gulp) {
-
-  // this sets the --harmony and --harmony-proxies flags on the node process
-  // this allows us to use `gulp` or `node` on swig tasks without specifying
-  // those flags (it's a good thing)
-  require('harmonize')();
-
   require('colors');
+
+  // we don't need this from v6 and above
+  if (process.version.startsWith('v5')) {
+    // this sets the --harmony and --harmony-proxies flags on the node process
+    // this allows us to use `gulp` or `node` on swig tasks without specifying
+    // those flags (it's a good thing)
+    console.log('  - Hijacking the command to inject --harmony and --harmony-proxies flags'.yellow);
+    console.log('    to the node process.'.yellow);
+    console.log('    Consider upgrading to latest LTS version of node, instead.'.yellow);
+    console.log('    i.e. `nvm install --lts`'.yellow);
+    require('harmonize')();
+  }
+
 
   var _ = require('underscore'),
     path = require('path'),

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "colors": "*",
     "fs-extra": "^0.26.4",
     "globby": "^4.0.0",
-    "harmonize": "*",
     "inquirer": "^0.11.0",
     "less": "^2.5.3",
     "mustache": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",

--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -29,7 +29,8 @@ if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
       });
     } catch (e) {
       swig.log.error('gulpfile.js tried to require some dev dependencies that failed. Are they installed?');
-      swig.log('     - ' + e.message);
+      swig.log(`      - ${e.message || e}`);
+      if (e.stack) swig.log(`        ${e.stack}`);
       process.exit(1);
     }
   }


### PR DESCRIPTION
The module `harmonize` was causing a weird infinite loop on `yarn` based installations. 

From node 6 and above we don't need that module anymore, therefore we can safely remove it and by doing so we are also able to start using `yarn` in our projects. YAY!