### PR TITLE
Improve the functionality of Swig's Node version check

### DIFF
--- a/bin/check_node_version
+++ b/bin/check_node_version
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+#  ________  ___       __   ___  ________
+# |\   ____\|\  \     |\  \|\  \|\   ____\
+# \ \  \___|\ \  \    \ \  \ \  \ \  \___|
+#  \ \_____  \ \  \  __\ \  \ \  \ \  \  ___
+#   \|____|\  \ \  \|\__\_\  \ \  \ \  \|\  \
+#     ____\_\  \ \____________\ \__\ \_______\
+#    |\_________\|____________|\|__|\|_______|
+#    \|_________|
+
+#    It's delicious.
+#    Brought to you by the fine folks at Gilt (http://github.com/gilt)
+
+# Set Desired Node version
+# This script will install the required version if the user does not have this version or one greater already installed.
+# comparison is done using major version number. Will not update to newer version of the same major version i.e. 4.1 --> 4.3
+DESIRED_NODE_MAJOR_VERSION=6
+
+# flag set if no previous version of node is found.
+NO_PREVIOUS_VERSION=false
+
+# source nvm for this session
+export NVM_DIR="$HOME/.nvm"
+NVM_SH_LOCATION="$NVM_DIR/nvm.sh"
+
+CURRENT_NVM_VERSION_GOOD=false
+
+# if user has no NVM fix it
+if ! nvm 2> /dev/null; then
+  if [ ! -e ${NVM_SH_LOCATION} ]; then
+    echo "NVM not detected in expected location (${NVM_SH_LOCATION}). Do you have it installed?"
+    exit 1
+  fi
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+fi
+
+# if there is a current version of node installed, get the version information
+if [ ! $(nvm ls current | egrep 'N\/A') ]; then
+  # some serious parsing of dodgy characters needed here just to get a number back for comparison below.
+  CURRENT_NODE_MAJOR_VERSION=$(nvm ls current | sed 's/.*v\([0-9]*\)\.[0-9]*\.[0-9]*.*/\1/' | sed 's/[^0-9]//g')
+
+  if [[ "${CURRENT_NODE_MAJOR_VERSION}" -ge "${DESIRED_NODE_MAJOR_VERSION}" ]]; then
+    CURRENT_NVM_VERSION_GOOD=true
+  fi
+fi
+
+# if the current version of node is not good enoguh, see what we have locally and use if good enough
+if [ "$CURRENT_NVM_VERSION_GOOD" = false ]; then
+  if [ $(nvm ls 'v*' | tail -n1 | egrep 'N\/A') ]; then
+    NO_PREVIOUS_VERSION=true
+  else
+    # get the major version of the latest installed version
+    MAJOR_VERSION_INSTALLED=$(nvm ls 'v*' | tail -n1 | sed 's/.*v\([0-9]*\)\.[0-9]*\.[0-9]*/\1/')
+  fi
+
+  #echo "NO_PREVIOUS_VERSION: $NO_PREVIOUS_VERSION"
+  #echo "MAJOR_VERSION_INSTALLED: $MAJOR_VERSION_INSTALLED"
+  #echo "DESIRED_NODE_VERSION: $DESIRED_NODE_VERSION"
+
+  if [ "$NO_PREVIOUS_VERSION" = true ] || [[ "$MAJOR_VERSION_INSTALLED" -lt "$DESIRED_NODE_MAJOR_VERSION" ]]; then
+    # node version installed is less than desired version.
+    echo ".  ${gray}You don't have node >= v${DESIRED_NODE_MAJOR_VERSION} installed, doing that now:${reset}"
+    nvm install ${DESIRED_NODE_MAJOR_VERSION}
+    echo "Installing global modules: gulp, @gilt-tech/swig ..."
+    npm install -g gulp @gilt-tech/swig > /dev/null
+    MAJOR_VERSION_INSTALLED=${DESIRED_NODE_MAJOR_VERSION}
+  else
+    echo "Using installed node v${NEWEST_INSTALLED_VERSION}"
+  fi
+
+
+  nvm use ${DESIRED_NODE_MAJOR_VERSION} >/dev/null
+fi
+

--- a/bin/swig
+++ b/bin/swig
@@ -48,21 +48,7 @@ echo "·  ${red}swig${reset}         v$SWIG_VERSION"
 # version of node. It's not required in production, as production should be using
 # the right version of node natively.
 if [ "$NODE_ENV" != "production" ]; then
-
-  # source nvm for this session
-  export NVM_DIR="$HOME/.nvm"
-  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-
-  # run node 5 allow errors to pass through to the user.
-
-  if ls $NVM_DIR/versions/node/v5.* 1> /dev/null 2>&1; then
-    echo "Node v5 already installed" 1> /dev/null 2>&1
-  else
-    echo ".  ${gray}You don't have node v5 installed, doing that now:${reset}"
-    nvm install 5
-  fi
-
-  nvm use 5 >/dev/null
+  source $dir/check_node_version
 fi
 
 if [ "$firstParam" == "init" ]; then

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig",
   "description": "Launching point for the Swig framework.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/gilt/gilt-swig",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Previously Swig dictated a specific major version of Node, now we will allow the user to have a version of node greater than is required, assuming backward compatibility.

As this change also dictates >= version 6 of Node, it is dependent on the PR being merged and published here: https://github.com/gilt/gilt-swig-run/pull/6